### PR TITLE
Animate contact status text entrance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,10 @@ scoping if you touch it.
   halo for legibility over content) + compact enquiry card (subject/message/
   reply email, honeypot field). POSTs to `/api/contact`; the email address
   appears nowhere in the page. Card animates via opacity/translate (not
-  display), status text auto-clears.
+  display), status text auto-clears. Status messages ("Sending…", "Sent — …",
+  errors) enter with a slide-up/fade (`setStatus()` in main.js re-adds
+  `.contact-status.pop` after a reflow flush so every message retriggers the
+  keyframes; disabled under `prefers-reduced-motion`).
 - **Labels** — uppercase, letter-spaced, `#666` weight 600.
 - **Carousel** — horizontal scroll-snap track, drag-to-scroll (a real drag
   suppresses the card link click; native link/image drag is blocked).

--- a/main.js
+++ b/main.js
@@ -1082,10 +1082,21 @@ function registerHeroPanel(toggle, panel, onOpen) {
     const status = document.getElementById('contact-status');
     const send = document.getElementById('contact-send');
 
+    // Swap the status text with a slide-up entrance; restart the animation
+    // even when a message replaces another (class removal alone won't retrigger)
+    function setStatus(text) {
+        status.textContent = text;
+        status.classList.remove('pop');
+        if (text) {
+            void status.offsetWidth; // flush so re-adding .pop restarts the keyframes
+            status.classList.add('pop');
+        }
+    }
+
     toggle.addEventListener('click', () => {
         const open = card.classList.toggle('open');
         toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
-        status.textContent = ''; // fresh card every toggle — no stale words
+        setStatus(''); // fresh card every toggle — no stale words
         if (open) document.getElementById('contact-subject').focus();
         else toggle.blur(); // release focus so the label reverts to grey
     });
@@ -1096,11 +1107,11 @@ function registerHeroPanel(toggle, panel, onOpen) {
         const message = document.getElementById('contact-message').value.trim();
         const reply = document.getElementById('contact-reply').value.trim();
         if (!subject || !message || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(reply)) {
-            status.textContent = 'All fields required';
+            setStatus('All fields required');
             return;
         }
         send.disabled = true;
-        status.textContent = 'Sending…';
+        setStatus('Sending…');
         try {
             const resp = await fetch('/api/contact', {
                 method: 'POST',
@@ -1111,18 +1122,18 @@ function registerHeroPanel(toggle, panel, onOpen) {
                 }),
             });
             if (!resp.ok) throw new Error((await resp.json()).error || 'failed');
-            status.textContent = 'Sent — I’ll get back to you!';
+            setStatus('Sent — I’ll get back to you!');
             card.reset();
             setTimeout(() => {
                 card.classList.remove('open');
                 toggle.setAttribute('aria-expanded', 'false');
-                status.textContent = '';
+                setStatus('');
                 send.disabled = false;
             }, 2200);
         } catch (err) {
-            status.textContent = 'Couldn’t send — try later';
+            setStatus('Couldn’t send — try later');
             send.disabled = false;
-            setTimeout(() => { status.textContent = ''; }, 3000); // don't let the error linger
+            setTimeout(() => { setStatus(''); }, 3000); // don't let the error linger
         }
     });
 })();

--- a/style.css
+++ b/style.css
@@ -786,6 +786,20 @@ h1 {
     letter-spacing: 0.02em;
 }
 
+/* Incoming status message — rises into place like the card itself opening */
+.contact-status.pop {
+    animation: status-in 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes status-in {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .contact-status.pop { animation: none; }
+}
+
 .contact-card button[type="submit"] {
     background: #16161d;
     border: 1px solid #26262e;


### PR DESCRIPTION
## What & why

The contact card's status line — "Sending…", "Sent — I'll get back to you!", and the error message — popped in with no transition, which felt abrupt next to the card's own animated entrance.

Every status message now gets a **slide-up + fade** entrance (rises ~6px while fading in, 0.35s, same easing as the card/panel animations), so the "Sent" confirmation reads as an intentional moment instead of a text swap.

## Changes

**`style.css`**
- `.contact-status.pop` runs a `status-in` keyframe (opacity 0→1, translateY 6px→0, `cubic-bezier(0.4, 0, 0.2, 1)` to match the site's other transitions).
- Disabled under `prefers-reduced-motion: reduce`.

**`main.js`** (contact corner)
- New `setStatus()` helper replaces the bare `status.textContent = …` assignments. It removes and re-adds `.pop` with a reflow flush in between, so back-to-back messages (Sending… → Sent) each retrigger the animation — class toggling alone wouldn't restart the keyframes.
- The `aria-live="polite"` announcement behavior is unchanged (text is still swapped via `textContent`).

## Verification

`node --check` passes; animation is CSS-only and additive. Please confirm on the Vercel preview: open Contact, submit an enquiry, and watch "Sending…" then "Sent — I'll get back to you!" each rise into place (and the validation message when submitting empty fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWmt2so8EuWgRVsLmhN9oN)_