### PR TITLE
Fix daily trend drifting from Apple Health (stale pushes + timezones)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ reveal panel system.
 | `index.html` | Single page: hero (name + GitHub/LinkedIn/Parklane reveal panels), globe, time/weather, Daily Vitals section (steps/distance/calories + trend), footer |
 | `style.css` | All styling. Dark theme: bg `#08080c`, text `#ececf0`, muted `#444`/`#666` |
 | `main.js` | Globe + travel trail + auto-tracking, vitals/weather/time fetch, hero-panel accordion animations, carousel drag-to-scroll, GitHub heatmap |
-| `api/update.js` | `POST /api/update` — Bearer-auth, rate-limited (1/30s); writes latest `vitals`, upserts a daily `vitals_history` snapshot (last 14 days), and appends distance-deduped stops to `location_history` (last 10) |
+| `api/update.js` | `POST /api/update` — Bearer-auth, rate-limited (1/30s); writes latest `vitals`, upserts a daily `vitals_history` snapshot (one row per device-local day — optional `date`/`tz` from the Shortcut, Jakarta fallback; same-day merges take the per-metric max so a stale push can't wipe totals; last 14 days), and appends distance-deduped stops to `location_history` (last 10) |
 | `api/data.js` | `GET /api/data` — reads `vitals` + `vitals_history` + `location_history` (60s cache), returns `{...vitals, history, locations}` |
 | `api/contact.js` | `POST /api/contact` — public enquiry box; honeypot + per-IP rate limit (1/min) + length caps; stores to KV list `enquiries` (newest first, cap 50; read in the Upstash data browser) and forwards to the inbox via Resend when `RESEND_API_KEY`/`CONTACT_EMAIL` are set (best-effort — KV write is the source of truth) |
 | `package.json` | `"type": "module"` (api/ is ESM) + `@vercel/kv` |
@@ -36,9 +36,12 @@ reveal panel system.
 1. **iOS Shortcut** (on Gary's phone) reads Apple Health (steps, distance,
    calories) + GPS, `POST`s JSON to `/api/update` with `Authorization: Bearer <AUTH_KEY>`.
 2. `update.js` validates auth + rate limit, stores the latest `vitals` object,
-   upserts today's entry into `vitals_history` (one row per Jakarta day,
-   capped to 14), and — if the ping is >80km from the last recorded stop —
-   appends it to `location_history` (capped to 10, dedupes daily movement).
+   upserts today's entry into `vitals_history` (one row per *device-local* day
+   — the Shortcut may send `date` (YYYY-MM-DD) or `tz` (IANA name) in the JSON
+   body, else Jakarta is assumed; same-day rows merge by per-metric `Math.max`
+   because daily Health totals only grow — capped to 14), and — if the ping is
+   >80km from the last recorded stop — appends it to `location_history`
+   (capped to 10, dedupes daily movement).
 3. Browser `GET`s `/api/data` on load and every 5 min; falls back to demo
    values when the API 404s (e.g. local dev). Response includes `history` + `locations`.
 4. `lat/lng` repositions the globe pin and triggers the Open-Meteo weather/timezone fetch.

--- a/api/update.js
+++ b/api/update.js
@@ -1,5 +1,20 @@
 import { kv } from '@vercel/kv';
 
+// The Health "day" a push belongs to. Apple Health buckets daily totals by the
+// *device's* midnight, so prefer an explicit date or IANA timezone sent by the
+// iOS Shortcut; fall back to Jakarta (home) when neither is present.
+function resolveDay(body) {
+	const date = body && body.date;
+	if (typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date)) return date;
+	const tz = body && body.tz;
+	if (typeof tz === 'string' && tz) {
+		try {
+			return new Date().toLocaleDateString('en-CA', { timeZone: tz });
+		} catch (e) { /* unknown timezone name — fall through to home */ }
+	}
+	return new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Jakarta' });
+}
+
 // Great-circle distance in km — used to de-dupe location pings into real "stops"
 function haversineKm(la1, lo1, la2, lo2) {
 	const R = 6371, r = d => d * Math.PI / 180;
@@ -47,9 +62,12 @@ export default async function handler(req, res) {
 		await kv.set('last_update_time', now);
 
 		// Daily history for sparklines — best-effort, never break the main update.
-		// One entry per Jakarta day; later pushes overwrite (steps accumulate).
+		// One entry per device-local day (see resolveDay). Daily totals only ever
+		// grow, so same-day merges take the per-metric max — a stale push (phone
+		// not yet synced with the Watch) or a post-midnight ~0 reset landing on
+		// the previous day's row (device ahead of Jakarta) can't wipe real data.
 		try {
-			const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Jakarta' });
+			const today = resolveDay(req.body);
 			let history = (await kv.get('vitals_history')) || [];
 			const entry = {
 				date: today,
@@ -58,7 +76,18 @@ export default async function handler(req, res) {
 				calories: data.calories,
 			};
 			const idx = history.findIndex(h => h.date === today);
-			if (idx >= 0) history[idx] = entry; else history.push(entry);
+			if (idx >= 0) {
+				const prev = history[idx];
+				history[idx] = {
+					date: today,
+					steps: Math.max(Number(prev.steps) || 0, entry.steps),
+					distance: Math.max(Number(prev.distance) || 0, entry.distance),
+					calories: Math.max(Number(prev.calories) || 0, entry.calories),
+				};
+			} else {
+				history.push(entry);
+			}
+			history.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
 			history = history.slice(-14); // keep ~2 weeks
 			await kv.set('vitals_history', history);
 		} catch (e) {


### PR DESCRIPTION
## The bug

The trend chart's stored days can end up far below the real Apple Health totals (e.g. a full day showing **645 steps / 0.4 km / 12 cal**). Two mechanisms in `api/update.js`:

1. **Last-write-wins.** Every push *overwrote* today's `vitals_history` row. Daily Health totals only ever grow, so any push carrying a lower number — the iPhone pushing before the Apple Watch has synced its steps into Health, for example — permanently clobbered the real total if it was the day's last write.
2. **Day boundary hardcoded to Jakarta.** Apple Health buckets by the *device's* midnight. In a timezone ahead of Jakarta, a push just after device-midnight carries the new day's near-zero totals but was keyed to *yesterday's* Jakarta date — stamping ~0 over a completed day.

## The fix

- **Same-day rows merge by per-metric `Math.max`** instead of overwriting — a completed day can never lose data, while normal accumulation still raises it.
- **`resolveDay()`**: the Shortcut may optionally include `date` (`YYYY-MM-DD`) or `tz` (IANA name, e.g. `Asia/Tokyo`) in the JSON body to key the row to the device's day. Invalid values and the no-field case fall back to Jakarta, so the **existing Shortcut keeps working unchanged** — and even without it, the max-merge alone already stops the midnight wipe.
- History is kept date-sorted before the 14-day cap.

CLAUDE.md updated to match. No front-end or `data.js` changes — the chart just renders whatever history it gets.

## Verification

Ran the real handler against a stubbed `@vercel/kv` through 9 scenarios, all passing: stale lower push can't clobber a day; higher push still raises it; a post-midnight ~0 push creates its own row and leaves yesterday intact; `tz` keys to the device day; missing/garbage `date`/`tz` fall back to Jakarta; history stays sorted and capped at 14. `node --check` passes.

## Optional Shortcut upgrade

For exact day attribution while travelling, add one field to the Shortcut's JSON: `"date"` = *Current Date* formatted `yyyy-MM-dd` (device-local). Not required — everything above works without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWmt2so8EuWgRVsLmhN9oN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWmt2so8EuWgRVsLmhN9oN)_