### PR TITLE
Fix trend chart taps swallowed by the contact corner on mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,12 +140,17 @@ scoping if you touch it.
   display), status text auto-clears. Status messages ("Sending…", "Sent — …",
   errors) enter with a slide-up/fade (`setStatus()` in main.js re-adds
   `.contact-status.pop` after a reflow flush so every message retriggers the
-  keyframes; disabled under `prefers-reduced-motion`).
+  keyframes; disabled under `prefers-reduced-motion`). ⚠️ `.contact-corner`
+  is `pointer-events: none` — its box silently spans the closed card's full
+  size over the bottom of the page (it blocked the trend chart's taps on
+  phones); only the toggle and the `.open` card re-enable pointer events.
+  Keep that if you add children to the corner.
 - **Labels** — uppercase, letter-spaced, `#666` weight 600.
 - **Carousel** — horizontal scroll-snap track, drag-to-scroll (a real drag
   suppresses the card link click; native link/image drag is blocked).
 - **Trend chart** — weekly steps/distance/calories overlay under Daily Vitals,
-  hover for a per-day tooltip (pinch-zoom aware, same as the GitHub tooltip).
+  hover/tap for a per-day tooltip (pinch-zoom aware and edge-clamped, same as
+  the GitHub tooltip).
 
 ## Local preview
 

--- a/main.js
+++ b/main.js
@@ -774,11 +774,15 @@ function renderTrend(history) {
         const h = recent[i];
         tip.innerHTML = `<span class="trend-tip-date">${fmtTrendDate(h.date)}</span>`
             + TREND_METRICS.map(({ key, color }) => `<span class="trend-tip-row"><i style="background:${color}"></i>${TREND_FMT[key](Number(h[key]) || 0)}</span>`).join('');
+        tip.classList.add('show'); // show first so the tip has measurable dimensions
         const sRect = svgEl.getBoundingClientRect();
         const vp = visualViewportBox(); // convert to layout coords so it stays put when pinch-zoomed
-        tip.style.left = (sRect.left + (x / TREND_W) * sRect.width + vp.left) + 'px';
+        // Anchor over the day, clamped on-screen so edge points stay readable (same as the heatmap tip)
+        const TIP_PAD = 8;
+        const half = tip.getBoundingClientRect().width / 2;
+        const rawX = sRect.left + (x / TREND_W) * sRect.width + vp.left;
+        tip.style.left = Math.max(vp.left + TIP_PAD + half, Math.min(rawX, vp.left + vp.width - TIP_PAD - half)) + 'px';
         tip.style.top = (sRect.top + vp.top) + 'px';
-        tip.classList.add('show');
     }
     function hide() {
         guideEl.setAttribute('opacity', '0');

--- a/style.css
+++ b/style.css
@@ -686,6 +686,15 @@ h1 {
     flex-direction: column;
     align-items: flex-end;
     gap: 0.5rem;
+    /* The container's box spans the closed card's full size (~270px wide) over
+       page content near the bottom — the vitals trend chart on phones. Only the
+       real controls may catch input: the toggle re-enables below, the card when
+       it gets .open. Without this the invisible box eats the chart's taps. */
+    pointer-events: none;
+}
+
+.contact-corner .contact-toggle {
+    pointer-events: auto;
 }
 
 .contact-toggle {


### PR DESCRIPTION
## The bug

On phones, only the leftmost point or two of the vitals trend chart responded to touch — the rest showed no tooltip.

The `.contact-corner` container (fixed, bottom-right) is a flex column holding the CONTACT toggle **and** the enquiry card. The closed card is invisible (`opacity: 0`) and correctly `pointer-events: none` — but it still occupies layout, so the *container's* box is ~270px wide and a few hundred px tall. The container itself had no `pointer-events` rule, so this invisible box hit-tested first and swallowed every tap over the bottom-right of the page — which on a 390px phone covers the chart from roughly x=100 rightward, leaving only the first couple of day-points reachable.

## The fix

**`style.css`** — `.contact-corner { pointer-events: none }`; the toggle re-enables its own events, and the card already re-enables them via `.contact-card.open`. Taps pass through the empty box to the chart beneath.

**`main.js`** — while here, the trend tooltip now clamps inside the visual viewport (`TIP_PAD = 8`, measured after showing), mirroring the heatmap tooltip, so first/last-day tooltips stay fully readable on narrow screens instead of being half-clipped at the edge.

## Verification

Reproduced and re-tested with headless-Chromium touch emulation at 390×844 (real globe.gl bundle, stubbed data APIs):

- **Before:** `elementFromPoint` at day-points 2–7 returned `DIV.contact-corner`; taps there never reached the SVG.
- **After:** all 7 points hit the chart's hit-rect, each shows its tooltip with the correct date, and every tooltip rect is fully on-screen.
- **Contact corner still works:** toggle tap opens the card (`aria-expanded="true"`), tapping the subject field focuses it, second toggle tap closes.

CLAUDE.md documents the pointer-events invariant so future corner children keep re-enabling their own events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWmt2so8EuWgRVsLmhN9oN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWmt2so8EuWgRVsLmhN9oN)_