### PR TITLE
Fix comet limb bug with an exact camera-ray depth test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,20 +81,18 @@ without them enquiries only land in KV).
   one tapered two-pass stroke (soft periwinkle glow + bright core, `lighter`
   compositing) — continuous at any speed (the old DOM-dot trail tore into
   visible dots on fast legs), flows across leg boundaries, and eases into a
-  city during the arrival hold. Far-side culling is altitude-aware
-  (`horizonAngle()` = 90° + acos(1/(1+alt)) — a raised arc stays visible past
-  the horizon). Arrival popup (`.replay-label`) shows at every stop, Jakarta
-  included. Tuning dials in main.js: `TRAIL_MS` (tail length), `TRAIL_SAMPLES`,
-  the `fade*fade` alpha curve + `rgba` peaks in the stroke loop, and
-  `COMET_HOLD_MS` / `COMET_LEG_BASE_MS` / `COMET_LEG_DIST_MS` (pacing).
-  Respects `prefers-reduced-motion` (comet off).
-  ⚠️ **Open issue:** the comet/trail is still sometimes visible behind the
-  globe near the limb, even after switching `horizonAngle()` to the
-  camera-distance-aware formula (acos(1/d) + acos(1/(1+alt))). Parked at
-  Gary's request. Next things to try: verify `pointOfView().altitude` is the
-  value assumed (camera may sit closer than `1+alt` suggests after globe.gl's
-  auto-fit), or ditch the analytic check and depth-test against the WebGL
-  scene (e.g. raycast, or compare the point's projected depth to the sphere's).
+  city during the arrival hold. Far-side culling is a true depth test:
+  `isBehindGlobe()` intersects the sightline from the *real* camera position
+  (`globe.camera().position`, via `getCoords`/`getGlobeRadius`) with the globe
+  sphere — a point is hidden iff the sphere is hit strictly before it (small
+  epsilon so surface points don't self-occlude). This replaced the old
+  analytic `horizonAngle()` estimate, which trusted `pointOfView().altitude`
+  as the camera distance and let the comet/trail peek through near the limb.
+  Arrival popup (`.replay-label`) shows at every stop, Jakarta included, and
+  uses the same check. Tuning dials in main.js: `TRAIL_MS` (tail length),
+  `TRAIL_SAMPLES`, the `fade*fade` alpha curve + `rgba` peaks in the stroke
+  loop, and `COMET_HOLD_MS` / `COMET_LEG_BASE_MS` / `COMET_LEG_DIST_MS`
+  (pacing). Respects `prefers-reduced-motion` (comet off).
 
 ## Hero reveal panels (GitHub / LinkedIn / Parklane)
 
@@ -194,8 +192,9 @@ implementing the one-liner ourselves and deleting the bot branch.
 
 ## Roadmap / parked ideas
 
-- **Comet limb bug** — the open issue above (comet visible behind the globe
-  near the edge); try a real depth test next.
+- ~~Comet limb bug~~ — fixed 2026-07: far-side culling is now an exact
+  ray-sphere depth test against the real camera (`isBehindGlobe()` in
+  main.js), replacing the analytic horizon-angle estimate.
 - **Projects showcase** — Experience now lives in the LinkedIn panel; a
   separate projects/cards section is still open if Gary wants one.
 - ~~OG image refresh~~ — regenerated 2026-07 with a crop-safe centered layout

--- a/main.js
+++ b/main.js
@@ -500,13 +500,28 @@ const cometLabel = document.createElement('div');
 cometLabel.className = 'replay-label';
 globeWrapper.appendChild(cometLabel);
 
-// Angular distance from the current view centre → used to hide things behind the globe
-function viewAngle(lat, lng) {
-    const pov = globe.pointOfView();
-    const r = d => d * Math.PI / 180;
-    const dLat = r(lat - pov.lat), dLng = r(lng - pov.lng);
-    const h = Math.sin(dLat / 2) ** 2 + Math.cos(r(pov.lat)) * Math.cos(r(lat)) * Math.sin(dLng / 2) ** 2;
-    return 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+// A point is hidden iff the straight line from the real camera to it passes
+// through the globe sphere first — an exact world-space occlusion test
+// (getCoords/getGlobeRadius/camera are globe.gl utilities; the sphere sits at
+// the scene origin). Replaces the old analytic horizon-angle estimate, which
+// trusted pointOfView().altitude as the camera distance and let the comet and
+// trail show through the globe near the limb.
+function isBehindGlobe(lat, lng, alt) {
+    const p = globe.getCoords(lat, lng, alt);
+    const c = globe.camera().position;
+    const R = globe.getGlobeRadius();
+    const dx = p.x - c.x, dy = p.y - c.y, dz = p.z - c.z;
+    const L = Math.hypot(dx, dy, dz);
+    if (!L) return false;
+    // ray-sphere: |C + t·d̂|² = R², nearest root
+    const bx = dx / L, by = dy / L, bz = dz / L;
+    const b = c.x * bx + c.y * by + c.z * bz;
+    const disc = b * b - (c.x * c.x + c.y * c.y + c.z * c.z - R * R);
+    if (disc <= 0) return false; // sightline misses the sphere entirely
+    const tHit = -b - Math.sqrt(disc);
+    // occluded only when the sphere is hit strictly before the point — the
+    // epsilon keeps points sitting ON the surface from occluding themselves
+    return tHit > 0 && tHit < L - R * 0.003;
 }
 
 let legIdx = 0, legT = 0, holdT = 0, replayDone = false;
@@ -526,15 +541,6 @@ function bezierPoint(leg, t) {
         lng: Math.atan2(y, x) * 180 / Math.PI,
         alt: rr - 1,
     };
-}
-
-// True visibility horizon for a camera at finite distance: a surface point
-// hides at acos(1/d) from the view centre (~73° at the default zoom, NOT 90°),
-// while altitude extends visibility by acos(1/(1+alt)). Small margin so
-// strokes don't linger on the limb.
-function horizonAngle(alt) {
-    const d = 1 + (globe.pointOfView().altitude || 2.5); // camera distance in globe radii
-    return Math.acos(1 / d) + Math.acos(1 / (1 + Math.max(0, alt))) - 0.02;
 }
 
 const trailHistory = []; // recent exact path positions: {lat, lng, alt, t}
@@ -582,7 +588,7 @@ function hideComet() {
     if (c) {
         comet.style.left = `${c.x}px`;
         comet.style.top = `${c.y}px`;
-        comet.style.opacity = viewAngle(lat, lng) < horizonAngle(alt) ? 1 : 0; // hide on far side
+        comet.style.opacity = isBehindGlobe(lat, lng, alt) ? 0 : 1; // hide on far side
     }
 
     // Trail — one continuous tapered stroke over the last TRAIL_MS of travel.
@@ -614,7 +620,7 @@ function hideComet() {
                 p = { lat: Math.asin(z / rr) * 180 / Math.PI, lng: Math.atan2(y, x) * 180 / Math.PI, alt: rr - 1 };
             }
             const sc = globe.getScreenCoords(p.lat, p.lng, p.alt);
-            pts.push(sc && viewAngle(p.lat, p.lng) < horizonAngle(p.alt) ? sc : null);
+            pts.push(sc && !isBehindGlobe(p.lat, p.lng, p.alt) ? sc : null);
         }
         trailCtx.globalCompositeOperation = 'lighter';
         trailCtx.lineCap = 'round';
@@ -651,7 +657,7 @@ function hideComet() {
         if (lc) {
             cometLabel.style.left = `${lc.x}px`;
             cometLabel.style.top = `${lc.y}px`;
-            cometLabel.style.opacity = viewAngle(labelCity.lat, labelCity.lng) < Math.PI / 2 ? 1 : 0;
+            cometLabel.style.opacity = isBehindGlobe(labelCity.lat, labelCity.lng, 0.04) ? 0 : 1;
         }
     } else {
         cometLabel.style.opacity = 0;


### PR DESCRIPTION
## The bug (roadmap: "comet limb bug")

The comet, its trail, and the arrival label were hidden behind the globe by an analytic horizon angle built from `pointOfView().altitude` — which bakes in two assumptions: the camera sits at exactly `1 + altitude` globe radii, and the pov center matches the camera axis. When either slipped (drag inertia, pinch zoom, fly-in transitions, auto-fit), the comet/trail stayed visible past the limb and slid across the dark side of the globe.

## The fix

`isBehindGlobe(lat, lng, alt)` — a true world-space depth test, as the roadmap suggested:

- Get the point's 3D position (`globe.getCoords`) and the **real** camera position (`globe.camera().position`).
- Intersect that sightline with the globe sphere (`getGlobeRadius`, scene origin) analytically.
- The point is hidden iff the sphere is hit **strictly before** the point (epsilon `R × 0.003` so points sitting on the surface don't self-occlude).

No assumption about camera state survives — the test is exact for any drag/zoom/transition. The comet head, all 33 trail samples, and the arrival label now share it. `viewAngle()`/`horizonAngle()` are deleted. Cost: ~34 small vector ops per frame, no THREE objects allocated.

## Verification

Headless Chromium against the **real globe.gl bundle**, calling the shipped `isBehindGlobe` in-page and comparing to an independent brute-force oracle (3,000-step march along the camera→point segment), over randomized `(lat, lng, alt)` sweeps with near-tangent points excluded:

| condition | points | new check vs oracle | old formula wrong |
|---|---|---|---|
| desktop 1200×800, at rest | 786 | **0 mismatches** | 8 |
| mobile 390×844 | 787 | **0 mismatches** | 8 |
| mid pointOfView zoom transition | 298 | **0 mismatches** | 3 |

Invariants also hold in every run: the view-center point is visible, the antipode hidden. The old formula misclassifies a band of points at the limb in every condition — the region the comet glides through on each leg. (I couldn't reproduce the exact drawn-while-behind camera state headlessly, but the new test can't have that class of failure: it never consults `pointOfView()`.)

Please eyeball the Vercel preview: watch a few comet legs wrap around the limb — the head and trail should now extinguish exactly at the edge, including while dragging and pinch-zooming.

CLAUDE.md: open-issue paragraph replaced with the new mechanism; roadmap item checked off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWmt2so8EuWgRVsLmhN9oN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWmt2so8EuWgRVsLmhN9oN)_