### PR TITLE
Self-heal undercounted history days via a days back-fill on /api/update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ reveal panel system.
 | `index.html` | Single page: hero (name + GitHub/LinkedIn/Parklane reveal panels), globe, time/weather, Daily Vitals section (steps/distance/calories + trend), footer |
 | `style.css` | All styling. Dark theme: bg `#08080c`, text `#ececf0`, muted `#444`/`#666` |
 | `main.js` | Globe + travel trail + auto-tracking, vitals/weather/time fetch, hero-panel accordion animations, carousel drag-to-scroll, GitHub heatmap |
-| `api/update.js` | `POST /api/update` — Bearer-auth, rate-limited (1/30s); writes latest `vitals`, upserts a daily `vitals_history` snapshot (one row per device-local day — optional `date`/`tz` from the Shortcut, Jakarta fallback; same-day merges take the per-metric max so a stale push can't wipe totals; last 14 days), and appends distance-deduped stops to `location_history` (last 10) |
+| `api/update.js` | `POST /api/update` — Bearer-auth, rate-limited (1/30s); writes latest `vitals`, upserts a daily `vitals_history` snapshot (one row per device-local day — optional `date`/`tz` from the Shortcut, Jakarta fallback; all merges take the per-metric max so a stale push can't wipe totals; optional `days: [{date, steps, distance, calories}]` back-fills recent dates, e.g. yesterday's final Health totals, ≤7 entries, future dates rejected; last 14 days), and appends distance-deduped stops to `location_history` (last 10) |
 | `api/data.js` | `GET /api/data` — reads `vitals` + `vitals_history` + `location_history` (60s cache), returns `{...vitals, history, locations}` |
 | `api/contact.js` | `POST /api/contact` — public enquiry box; honeypot + per-IP rate limit (1/min) + length caps; stores to KV list `enquiries` (newest first, cap 50; read in the Upstash data browser) and forwards to the inbox via Resend when `RESEND_API_KEY`/`CONTACT_EMAIL` are set (best-effort — KV write is the source of truth) |
 | `package.json` | `"type": "module"` (api/ is ESM) + `@vercel/kv` |
@@ -38,10 +38,14 @@ reveal panel system.
 2. `update.js` validates auth + rate limit, stores the latest `vitals` object,
    upserts today's entry into `vitals_history` (one row per *device-local* day
    — the Shortcut may send `date` (YYYY-MM-DD) or `tz` (IANA name) in the JSON
-   body, else Jakarta is assumed; same-day rows merge by per-metric `Math.max`
-   because daily Health totals only grow — capped to 14), and — if the ping is
-   >80km from the last recorded stop — appends it to `location_history`
-   (capped to 10, dedupes daily movement).
+   body, else Jakarta is assumed; rows merge by per-metric `Math.max` because
+   daily Health totals only grow — capped to 14). The Shortcut should also
+   send `days: [{date, steps, distance, calories}]` with *yesterday's* final
+   Health totals: a day whose last live push landed early (evening steps
+   never sent) self-heals on the next day's pushes. Same max merge, ≤7
+   entries, future dates rejected. Finally — if the ping is >80km from the
+   last recorded stop — it's appended to `location_history` (capped to 10,
+   dedupes daily movement).
 3. Browser `GET`s `/api/data` on load and every 5 min; falls back to demo
    values when the API 404s (e.g. local dev). Response includes `history` + `locations`.
 4. `lat/lng` repositions the globe pin and triggers the Open-Meteo weather/timezone fetch.

--- a/api/update.js
+++ b/api/update.js
@@ -69,23 +69,38 @@ export default async function handler(req, res) {
 		try {
 			const today = resolveDay(req.body);
 			let history = (await kv.get('vitals_history')) || [];
-			const entry = {
-				date: today,
-				steps: data.steps,
-				distance: data.distance,
-				calories: data.calories,
-			};
-			const idx = history.findIndex(h => h.date === today);
-			if (idx >= 0) {
+			const mergeDay = entry => {
+				const idx = history.findIndex(h => h.date === entry.date);
+				if (idx < 0) { history.push(entry); return; }
 				const prev = history[idx];
 				history[idx] = {
-					date: today,
+					date: entry.date,
 					steps: Math.max(Number(prev.steps) || 0, entry.steps),
 					distance: Math.max(Number(prev.distance) || 0, entry.distance),
 					calories: Math.max(Number(prev.calories) || 0, entry.calories),
 				};
-			} else {
-				history.push(entry);
+			};
+			mergeDay({
+				date: today,
+				steps: data.steps,
+				distance: data.distance,
+				calories: data.calories,
+			});
+			// Optional back-fill: `days` carries closed-out totals for recent
+			// dates (typically yesterday's final Health numbers, queried fresh by
+			// the Shortcut). Same max rule — so a day whose last live push landed
+			// early (evening steps never sent) self-heals on the next day's pushes.
+			if (Array.isArray(req.body.days)) {
+				for (const d of req.body.days.slice(0, 7)) {
+					if (!d || typeof d.date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(d.date)) continue;
+					if (d.date > today) continue; // a typo'd future date must not evict real rows
+					mergeDay({
+						date: d.date,
+						steps: Number(d.steps) || 0,
+						distance: Number(d.distance) || 0,
+						calories: Number(d.calories) || 0,
+					});
+				}
 			}
 			history.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
 			history = history.slice(-14); // keep ~2 weeks


### PR DESCRIPTION
## Why Jul 17 still shows 3,083 steps

The max-merge from PR #47 protects a day from being *overwritten* with a lower number — but it can't recover data the server **never received**. If the Shortcut's last push on the 17th ran mid-afternoon at 3,083 steps, everything walked after that was never sent anywhere; when the 18th began, the 17th's row was frozen at the last value it ever heard.

That's a client-timing gap, and no pure server change can fix it retroactively. What the server *can* do is accept corrections the next day — Health still knows the 17th's true total on the 18th.

## The change

`POST /api/update` now takes an optional **`days`** array of closed-out totals:

```json
{ "steps": 500, "distance": 0.3, "calories": 9,
  "days": [ { "date": "2026-07-17", "steps": 8412, "distance": 6.1, "calories": 210 } ] }
```

Each entry merges into `vitals_history` by the same per-metric `Math.max` as live pushes — so it can raise or create a day, never lower one. Guardrails: max 7 entries processed, `YYYY-MM-DD` validated, future dates rejected (a typo'd date can't evict real rows from the 14-day window). The today-upsert was refactored onto the same `mergeDay` helper. Fully backward compatible — pushes without `days` behave exactly as before.

**With the Shortcut sending yesterday's totals on every push, each day self-heals one day later** — the early-last-push gap and any late Watch sync both get folded in automatically.

## Verification

Ran the real handler against a stubbed `@vercel/kv` through 15 scenarios — the 9 existing regressions (max-merge, tz keying, fallback, sort/cap) plus 6 new: back-fill heals an undercounted yesterday, cannot lower a healed day, creates missing past rows, keeps history sorted, ignores garbage/future entries, caps at 7. All pass; `node --check` clean.

## Shortcut change (needed to activate)

Add to the Shortcut, after the existing Health queries:
1. **Find Health Samples** for Steps / Walking+Running Distance / Active Energy with date filter **Yesterday** (or "Get numeric value of Health sample" for yesterday's date range).
2. **Format yesterday's date** as `yyyy-MM-dd`.
3. Add to the JSON body: `"days": [{"date": "<that date>", "steps": <…>, "distance": <…>, "calories": <…>}]`.

Once merged + deployed, one push with `"days": [{"date": "2026-07-17", …true totals…}]` also fixes the 17th's row immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWmt2so8EuWgRVsLmhN9oN

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWmt2so8EuWgRVsLmhN9oN)_